### PR TITLE
Use direct connections with MongoClient

### DIFF
--- a/vc_cli/cli.py
+++ b/vc_cli/cli.py
@@ -103,6 +103,7 @@ def _load_versioned_collection(
         port=int(mongo_cfg['port']),
         username=mongo_cfg.get('username', None),
         password=mongo_cfg.get('password', None),
+        directConnection=True,
     )
 
     vc = VersionedCollection(

--- a/versioned_collection/collection/versioned_collection.py
+++ b/versioned_collection/collection/versioned_collection.py
@@ -879,6 +879,7 @@ class VersionedCollection(Collection):
             port=int(address[1]),
             username=credentials[0],
             password=credentials[1],
+            directConnection=True,
         )
         database = client[database_name]
 

--- a/versioned_collection/listener.py
+++ b/versioned_collection/listener.py
@@ -175,7 +175,11 @@ class CollectionListener:
         :param lock: A lock used to synchronise the shared variables.
         """
         client = MongoClient(
-            host=host, port=port, username=username, password=password
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            directConnection=True,
         )
         target_collection = client[database_name][collection_name]
 


### PR DESCRIPTION
Fixes authentications issues with replica sets when ssh tunnelling to a remote collection