### PR TITLE
feat(auth): Fetch missing authentication credentials from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ----
 
-[![Tests](https://github.com/HumanisingAutonomy/versioned_collection/actions/workflows/release.yml/badge.svg)](https://github.com/HumanisingAutonomy/versioned_collection/actions/workflows/release.yaml)
+[![Tests](https://github.com/HumanisingAutonomy/versioned_collection/actions/workflows/release.yaml/badge.svg)](https://github.com/HumanisingAutonomy/versioned_collection/actions/workflows/release.yaml)
 [![codecov](https://codecov.io/github/HumanisingAutonomy/versioned_collection/graph/badge.svg?token=5AS1HJSQAW)](https://codecov.io/github/HumanisingAutonomy/versioned_collection)
 [![Documentation](https://readthedocs.org/projects/versioned-collection/badge/?version=latest)](https://versioned-collection.readthedocs.io/latest/)
 
@@ -105,6 +105,10 @@ bands_collection = VersionedCollection(
     password=password
 )
 ```
+
+Alternatively, `username` and `password` can be updated based on the 
+environment variables `VC_MONGO_USER` and `VC_MONGO_PASSWORD` respectively. The
+code provided variables have priority.
 </details>
 
 </details>

--- a/tests/test_tracking_collection/test_deltas.py
+++ b/tests/test_tracking_collection/test_deltas.py
@@ -16,7 +16,7 @@ from versioned_collection.collection.tracking_collections import DeltasCollectio
 def _get_timestamp():
     # bson stores date times up to millisecond precision, so chop of the
     # nanoseconds
-    timestamp = datetime.datetime.utcnow()
+    timestamp = datetime.datetime.now()
     timestamp = datetime.datetime.fromisoformat(
         timestamp.isoformat(timespec='milliseconds')
     )
@@ -90,7 +90,7 @@ class TestDeltasCollectionIntegration(InMemoryDatabaseSetup):
             document_id=self.doc['_id'],
             collection_version=1,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             branch_history=[],
         )
         self.assertIsNone(delta_id)

--- a/tests/test_tracking_collection/test_log.py
+++ b/tests/test_tracking_collection/test_log.py
@@ -21,7 +21,7 @@ class TestLogSchema(TestCase):
         self.entry = LogsCollection.SCHEMA(
             version=0,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='Some message',
             prev=None,
             next=[ObjectId(), ObjectId()],
@@ -117,7 +117,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
 
     def test_build_creates_a_log_entry(self):
         col = self._get_collection()
-        timestamp = datetime.datetime.utcnow()
+        timestamp = datetime.datetime.now(datetime.timezone.utc)
         message = 'Test initial version.'
         _id = ObjectId()
 
@@ -147,7 +147,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
             _id=root_id,
             version=0,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='root',
             prev=None,
             next=[child_id],
@@ -156,7 +156,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
             _id=child_id,
             version=1,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='v1',
             prev=root_id,
             next=[],
@@ -165,7 +165,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
         e3 = dict(
             version=2,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='v2',
             prev=None,
             next=[],
@@ -186,7 +186,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
         e1 = dict(
             version=0,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='root',
             prev=None,
             next=[child_id],
@@ -195,7 +195,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
             _id=child_id,
             version=1,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='v1',
             prev=ObjectId(),
             next=[],
@@ -213,7 +213,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
         entry = dict(
             version=0,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='root',
             prev=ObjectId(),
             next=[],
@@ -235,7 +235,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
             _id=root_id,
             version=0,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='root',
             prev=None,
             next=[child_1_id, child_2_id],
@@ -244,7 +244,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
             _id=child_1_id,
             version=1,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='v1',
             prev=root_id,
             next=[],
@@ -253,7 +253,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
             _id=child_2_id,
             version=0,
             branch='branch',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='other branch',
             prev=root_id,
             next=[],
@@ -351,7 +351,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
             _id=root_id,
             version=0,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='root',
             prev=None,
             next=[child_id],
@@ -360,7 +360,7 @@ class TestLogCollectionBasics(InMemoryDatabaseSetup):
             _id=child_id,
             version=1,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='v1',
             prev=root_id,
             next=[root_id],
@@ -414,7 +414,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             _id=root_id,
             version=0,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='root',
             prev=None,
             next=[v1_main_id, v0_b1_id],
@@ -423,7 +423,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             _id=v1_main_id,
             version=1,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='v1',
             prev=root_id,
             next=[v2_main_id, v0_b2_id, v0_b3_id],
@@ -432,7 +432,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             _id=v2_main_id,
             version=2,
             branch='main',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='v2',
             prev=v1_main_id,
             next=[],
@@ -441,7 +441,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             _id=v0_b1_id,
             version=0,
             branch='b1',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='a branch',
             prev=root_id,
             next=[],
@@ -450,7 +450,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             _id=v0_b2_id,
             version=0,
             branch='b2',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='another branch',
             prev=v1_main_id,
             next=[],
@@ -459,7 +459,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             _id=v0_b3_id,
             version=0,
             branch='b3',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='yet another branch',
             prev=v1_main_id,
             next=[v1_b3_id, v0_b4_id],
@@ -468,7 +468,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             _id=v1_b3_id,
             version=1,
             branch='b3',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='some version on yet another branch',
             prev=v0_b3_id,
             next=[],
@@ -477,7 +477,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             _id=v0_b4_id,
             version=0,
             branch='b4',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             message='yet some other branch',
             prev=v0_b3_id,
             next=[],
@@ -747,7 +747,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
                 previous_branch='b1',
                 current_branch='b1',
                 message='this will not be recorded',
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(datetime.timezone.utc),
             )
 
     @patch.object(pymongo.collection.Collection, 'insert_one')
@@ -762,7 +762,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             previous_branch='main',
             current_branch='b5',
             message='first version on b5',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             with_id=ObjectId(),
         )
         inserted_result_mock = MagicMock()
@@ -796,7 +796,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             previous_branch=None,
             current_branch='main',
             message='root',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             with_id=ObjectId(),
         )
 
@@ -825,7 +825,7 @@ class TestLogsCollection(InMemoryDatabaseSetup):
             previous_branch=None,
             current_branch='b4',
             message='a version',
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
             with_id=ObjectId(),
         )
         inserted_result_mock = MagicMock()

--- a/tests/test_versioned_collection/common.py
+++ b/tests/test_versioned_collection/common.py
@@ -1,3 +1,4 @@
+import os
 from time import sleep
 from typing import List
 from unittest import TestCase
@@ -27,13 +28,21 @@ class User(VersionedCollection):
         return super().diff(*args, **kwargs)
 
 
+def _fetch_connection_string() -> str:
+    username = os.getenv("VC_MONGO_USER", "")
+    password = os.getenv("VC_MONGO_PASSWORD", "")
+    credentials = f"{username}:{password}@" if len(username) else ""
+    host = "localhost"
+    port = 27017
+    return f"mongodb://{credentials}{host}:{port}"
+
+
 class _BaseTest(TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
         super(_BaseTest, cls).setUpClass()
-        conn_str = "mongodb://localhost:27017"
-        connection = MongoClient(conn_str)
+        connection = MongoClient(_fetch_connection_string())
         _database_name = "__test__db"
         cls.database = connection[_database_name]
         cls._database_name = _database_name
@@ -55,7 +64,7 @@ class _RemoteBaseTest(TestCase):
     def setUpClass(cls) -> None:
         # TODO: move to `mongomock`
         super(_RemoteBaseTest, cls).setUpClass()
-        conn_str = "mongodb://localhost:27017"
+        conn_str = _fetch_connection_string()
         connection_local = MongoClient(conn_str)
         cls.db_local = connection_local["__test__db_local"]
         connection_remote = MongoClient(conn_str)

--- a/tests/test_versioned_collection/test_basics.py
+++ b/tests/test_versioned_collection/test_basics.py
@@ -1,6 +1,10 @@
+import os
+from unittest import mock
+
 import pymongo
 
 from tests.test_versioned_collection.common import _BaseTest
+from versioned_collection import VersionedCollection
 
 
 class TestVersionedCollectionBasics(_BaseTest):
@@ -132,3 +136,23 @@ class TestVersionedCollectionBasics(_BaseTest):
         out = self.user_collection.aggregate_raw_batches([{'$match': {}}])
         self.assertFalse(self.user_collection.has_changes())
         self.assertEqual(1, len(list(out)))  # this is 1 batch
+
+
+class AuthTest(_BaseTest):
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "VC_MONGO_USER": "mongo",
+            "VC_MONGO_PASSWORD": "pswd",
+        },
+    )
+    def test_uses_env_variables_if_defined(self):
+        collection = VersionedCollection(self.database, "User")
+
+        # FIXME: forgive me lord for i have sinned
+        user, password = collection.__dict__[
+            '_VersionedCollection__credentials'
+        ]
+        self.assertEqual(user, "mongo")
+        self.assertEqual(password, "pswd")

--- a/versioned_collection/collection/tracking_collections/logs.py
+++ b/versioned_collection/collection/tracking_collections/logs.py
@@ -236,7 +236,9 @@ class LogsCollection(_BaseTrackerCollection):
         self._levels = dict()
         message = "Initial collection." if message is None else message
         timestamp = (
-            datetime.datetime.utcnow() if timestamp is None else timestamp
+            datetime.datetime.now(datetime.timezone.utc)
+            if timestamp is None
+            else timestamp
         )
 
         self.add_log_entry(


### PR DESCRIPTION
Other changes:
- remove deprecated calls to `datetime.utcnow()`
- use context managers to close the `MongoClient` in parallel jobs 